### PR TITLE
Update heredoc syntax

### DIFF
--- a/autoload/ruby_heredoc_syntax.vim
+++ b/autoload/ruby_heredoc_syntax.vim
@@ -67,14 +67,15 @@ function! ruby_heredoc_syntax#enable_heredoc_highlight(filetype, start)
   let start_region = ruby_heredoc_syntax#syntax_start_region(a:filetype)
   let code_region = ruby_heredoc_syntax#syntax_code_region(a:filetype)
 
-  let regexp1 = "\\%(\\%(class\\s*\\|\\%([]})\"'.]\\|::\\)\\)\\_s*\\|\\w\\)\\@<!<<-\\=\\zs".a:start
+  let regexp1 = "\\%(\\%(class\\s*\\|\\%([]})\"'.]\\|::\\)\\)\\_s*\\|\\w\\)\\@<!<<-\\=\\zs['`\"]\\=".a:start
   let syntax1 = 'syntax region '.start_region.' matchGroup=rubyStringDelimiter start=+'.regexp1.'+ end=+$+ oneline contains=ALLBUT,@rubyNotTop'
 
-  let regexp2 = "\\%(\\%(class\\|::\\)\\_s*\\|\\%([]}).]\\)\\s\\|\\w\\)\\@<!<<\\z(".a:start."\\)\\ze\\%(.*<<-\\=['`\"]\\=\\h\\)\\@!"
-  let syntax2 = 'syntax region '.code_region.' matchGroup=rubyStringDelimiter start=+'.regexp2.'+hs=s+2 end=+^\z1$+ contains='.start_region.',@'.group.' fold keepend'
+  let regexp2 = "\\%(\\%(class\\|::\\)\\_s*\\|\\%([]}).]\\)\\s\\|\\w\\)\\@<!<<['`\"]\\=".a:start."['`\"]\\=\\ze\\%(.*<<-\\=['`\"]\\=\\h\\)\\@!"
+  let syntax2 = 'syntax region '.code_region.' matchGroup=rubyStringDelimiter start=+'.regexp2.'+hs=s+2 end=+^'.a:start.'$+ contains='.start_region.',@'.group.' fold keepend'
 
   let regexp3 = "\\%(\\%(class\\|::\\)\\_s*\\|\\%([]}).]\\)\\s\\|\\w\\)\\@<!<<-\\z(".a:start."\\)\\ze\\%(.*<<-\\=['`\"]\\=\\h\\)\\@!"
-  let syntax3 = 'syntax region '.code_region.' matchGroup=rubyStringDelimiter start=+'.regexp3.'+hs=s+3 end=+^\s*\zs\z1$+ contains='.start_region.',@'.group.' fold keepend'
+  let regexp3 = "\\%(\\%(class\\|::\\)\\_s*\\|\\%([]}).]\\)\\s\\|\\w\\)\\@<!<<-['`\"]\\=".a:start."['`\"]\\=\\ze\\%(.*<<-\\=['`\"]\\=\\h\\)\\@!"
+  let syntax3 = 'syntax region '.code_region.' matchGroup=rubyStringDelimiter start=+'.regexp3.'+hs=s+3 end=+^\s*\zs'.a:start.'$+ contains='.start_region.',@'.group.' fold keepend'
 
   execute syntax1
   execute syntax2

--- a/autoload/ruby_heredoc_syntax.vim
+++ b/autoload/ruby_heredoc_syntax.vim
@@ -67,14 +67,14 @@ function! ruby_heredoc_syntax#enable_heredoc_highlight(filetype, start)
   let start_region = ruby_heredoc_syntax#syntax_start_region(a:filetype)
   let code_region = ruby_heredoc_syntax#syntax_code_region(a:filetype)
 
-  let regexp1 = "\\%(\\%(class\\s*\\|\\%([]})\"'.]\\|::\\)\\)\\_s*\\|\\w\\)\\@<!<<-\\=\\zs['`\"]\\=".a:start
+  let regexp1 = "\\%(\\%(class\\s*\\|\\%([]})\"'.]\\|::\\)\\)\\_s*\\|\\w\\)\\@<!<<[-~]\\=\\zs['`\"]\\=".a:start
   let syntax1 = 'syntax region '.start_region.' matchGroup=rubyStringDelimiter start=+'.regexp1.'+ end=+$+ oneline contains=ALLBUT,@rubyNotTop'
 
-  let regexp2 = "\\%(\\%(class\\|::\\)\\_s*\\|\\%([]}).]\\)\\s\\|\\w\\)\\@<!<<['`\"]\\=".a:start."['`\"]\\=\\ze\\%(.*<<-\\=['`\"]\\=\\h\\)\\@!"
+  let regexp2 = "\\%(\\%(class\\|::\\)\\_s*\\|\\%([]}).]\\)\\s\\|\\w\\)\\@<!<<['`\"]\\=".a:start."['`\"]\\=\\ze\\%(.*<<[-~]\\=['`\"]\\=\\h\\)\\@!"
   let syntax2 = 'syntax region '.code_region.' matchGroup=rubyStringDelimiter start=+'.regexp2.'+hs=s+2 end=+^'.a:start.'$+ contains='.start_region.',@'.group.' fold keepend'
 
   let regexp3 = "\\%(\\%(class\\|::\\)\\_s*\\|\\%([]}).]\\)\\s\\|\\w\\)\\@<!<<-\\z(".a:start."\\)\\ze\\%(.*<<-\\=['`\"]\\=\\h\\)\\@!"
-  let regexp3 = "\\%(\\%(class\\|::\\)\\_s*\\|\\%([]}).]\\)\\s\\|\\w\\)\\@<!<<-['`\"]\\=".a:start."['`\"]\\=\\ze\\%(.*<<-\\=['`\"]\\=\\h\\)\\@!"
+  let regexp3 = "\\%(\\%(class\\|::\\)\\_s*\\|\\%([]}).]\\)\\s\\|\\w\\)\\@<!<<[-~]['`\"]\\=".a:start."['`\"]\\=\\ze\\%(.*<<[-~]\\=['`\"]\\=\\h\\)\\@!"
   let syntax3 = 'syntax region '.code_region.' matchGroup=rubyStringDelimiter start=+'.regexp3.'+hs=s+3 end=+^\s*\zs'.a:start.'$+ contains='.start_region.',@'.group.' fold keepend'
 
   execute syntax1

--- a/plugin/ruby_heredoc_syntax.vim
+++ b/plugin/ruby_heredoc_syntax.vim
@@ -90,7 +90,6 @@ function! s:enable_heredoc_syntax()
   let defaults = deepcopy(g:ruby_heredoc_syntax_defaults)
   let filetype_dic = extend(defaults, g:ruby_heredoc_syntax_filetypes)
 
-
   for [filetype, option] in items(filetype_dic)
     call ruby_heredoc_syntax#include_other_syntax(filetype)
     call ruby_heredoc_syntax#enable_heredoc_highlight(filetype, option.start)


### PR DESCRIPTION
This brings the plugin up to date in two ways:

* Support for the "squiggly heredoc" (partially addresses #1)
* Support for quoted delimiters, e.g. `<<'SQL'`

I've left the neosnippet/context filetype stuff alone as I don't use it and have no way of testing it.