### PR TITLE
Remove coffee script as default

### DIFF
--- a/plugin/ruby_heredoc_syntax.vim
+++ b/plugin/ruby_heredoc_syntax.vim
@@ -35,9 +35,6 @@ if !exists('g:ruby_heredoc_syntax_defaults')
         \ "javascript" : {
         \   "start" : "JS",
         \},
-        \ "coffee" : {
-        \   "start" : "COFFEE",
-        \},
         \ "sql" : {
         \   "start" : "SQL",
         \},
@@ -57,11 +54,6 @@ let s:context_filetypes_ruby = {
 \     'start' : '\%(\%(class\s*\|\%([]})".]\|::\)\)\_s*\|\w\)\@<!<<-\=\zsJS',
 \     'end' : '^\s*\zsJS$',
 \     'filetype' : 'javascript',
-\   },
-\   {
-\     'start' : '\%(\%(class\s*\|\%([]})".]\|::\)\)\_s*\|\w\)\@<!<<-\=\zsCOFFEE',
-\     'end' : '^\s*\zsCOFFEE$',
-\     'filetype' : 'coffee',
 \   },
 \   {
 \     'start' : '\%(\%(class\s*\|\%([]})".]\|::\)\)\_s*\|\w\)\@<!<<-\=\zsHTML',


### PR DESCRIPTION
Since coffeescript syntax is not included with vim, i think it makes sense to remove it as a default. This may cause some small pain for exisiting coffee script users, but it makes it much easier to adopt for new users.