### PR TITLE
Enable syntax matching for rspec

### DIFF
--- a/plugin/ruby_heredoc_syntax.vim
+++ b/plugin/ruby_heredoc_syntax.vim
@@ -91,6 +91,7 @@ endfunction
 augroup ruby_heredoc_syntax
   autocmd!
   autocmd Syntax ruby call s:enable_heredoc_syntax()
+  autocmd Syntax ruby.rspec call s:enable_heredoc_syntax()
 augroup END
 
 let g:loaded_ruby_heredoc_syntax = 1


### PR DESCRIPTION
Also apply the syntax highlighting to files with a syntax setting of `ruby.rspec`.

References joker1007/vim-ruby-heredoc-syntax#8